### PR TITLE
Fix wrong url of ICML 2018

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -44,7 +44,7 @@
 - name: ICML
   year: 2018
   id: icml18
-  link: https://2017.icml.cc/Conferences/2018
+  link: https://icml.cc/Conferences/2018
   deadline: "2018-02-09 19:59:59"
   timezone: EST
   date: July 10-15, 2018


### PR DESCRIPTION
Fix the original url of ICML 2018 with correct url.