### PR TITLE
Add Conference on Robot Learning (CoRL) 2018

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -61,6 +61,16 @@
   place: Brussels, Belgium
   sub: NLP
 
+- name: CoRL
+  year: 2018
+  id: corl2018
+  link: http://www.robot-learning.org/
+  deadline: "2018-06-15 23:59:59"
+  timezone: America/Los_Angeles
+  date:  October 29-31, 2018
+  place: Zurich, Switzerland
+  sub: RO
+
 - name: WACV
   year: 2019
   id: wacv19


### PR DESCRIPTION
This PR adds a conference on robot learning.

As for the deadline, only the day is announced as of now. To comply with your guidelines, I assumed the midnight in the time zone of Berkeley, the group that initiated the conference.