### PR TITLE
Add templated .ics file

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -290,3 +290,13 @@
   date: May 20-24, 2019
   place: Montreal, Canada
   sub: RO
+
+- name: TEST
+  year: 2019
+  id: test2019
+  link: https://icra2019.org//
+  deadline: "2018-11-15 23:59:59"
+  timezone: Etc/GMT
+  date: May 20-24, 2019
+  place: Montreal, Canada
+  sub: RO

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -290,13 +290,3 @@
   date: May 20-24, 2019
   place: Montreal, Canada
   sub: RO
-
-- name: TEST
-  year: 2019
-  id: test2019
-  link: https://icra2019.org//
-  deadline: "2018-11-15 23:59:59"
-  timezone: Etc/GMT
-  date: May 20-24, 2019
-  place: Montreal, Canada
-  sub: RO

--- a/_layouts/calendar.ics
+++ b/_layouts/calendar.ics
@@ -2,6 +2,7 @@ BEGIN:VCALENDAR
 METHOD:PUBLISH
 VERSION:2.0
 PRODID:-//{{ site.domain }}//ai-deadlines//EN
+X-PUBLISHED-TTL:PT1H
 {%- for conf in site.data.conferences -%}
 {% if conf.deadline != "TBA" %}
 BEGIN:VEVENT

--- a/_layouts/calendar.ics
+++ b/_layouts/calendar.ics
@@ -1,0 +1,14 @@
+BEGIN:VCALENDAR
+METHOD:PUBLISH
+VERSION:2.0
+PRODID:-//{{ site.domain }}//ai-deadlines//EN
+{%- for conf in site.data.conferences -%}
+{% if conf.deadline != "TBA" %}
+BEGIN:VEVENT
+SUMMARY:{{ conf.name }} {{ conf.year }} deadline
+UID:{{ conf.id }}
+DTSTART;TZID={{ conf.timezone }}:{{ conf.deadline | date: "%Y%m%dT%H%M%S" }}
+END:VEVENT
+{% endif %}
+{%- endfor -%}
+END:VCALENDAR

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -32,6 +32,10 @@
                 <div class="meta col-xs-12">
                   {{ site.description }}
                   To add/update a conference, <a target="_blank" href="//github.com/{{ site.github_username }}/{{ site.github_repo }}">send in a pull request</a>.
+                  <br>
+                  <a href="https://calendar.google.com/calendar/r?cid={{ site.url }}/calendar.ics">Export all deadlines to Google Calendar</a>
+                  <br>
+                  <a href="/calendar.ics">Export all deadlines to .ics file</a>
                 </div>
             </div>
             <br>

--- a/calendar.ics
+++ b/calendar.ics
@@ -1,0 +1,3 @@
+---
+layout: calendar
+---


### PR DESCRIPTION
This PR request adds a `calendar.ics` file that is automatically populated from `conferences.yml`, as well as links to either import this file to Google Calendar or directly download it.