### PR TITLE
Fix the broken .ics

### DIFF
--- a/_layouts/calendar.ics
+++ b/_layouts/calendar.ics
@@ -6,7 +6,7 @@ X-PUBLISHED-TTL:PT1H
 {%- for conf in site.data.conferences -%}
 {% if conf.deadline != "TBA" %}
 BEGIN:VEVENT
-SUMMARY:{{ conf.name }} {{ conf.year }} deadline
+SUMMARY:{{ conf.title }} {{ conf.year }} deadline
 UID:{{ conf.id }}
 DTSTART;TZID={{ conf.timezone }}:{{ conf.deadline | date: "%Y%m%dT%H%M%S" }}
 END:VEVENT


### PR DESCRIPTION
Hey there, since the `conf.name` has been renamed to `conf.title`, the .ics is currently broken.
<img width="950" alt="2018-12-24 1 36 24" src="https://user-images.githubusercontent.com/22514219/50386151-65ce2c00-071c-11e9-9223-2178caf19d69.png">
All names of conferences now cannot display. This PR helps fix that.