### PR TITLE
ICCV 2019 date changed

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -7,7 +7,7 @@
   link: http://iccv2019.thecvf.com/
   deadline: '2019-03-22 23:59:00'
   timezone: America/Los_Angeles
-  date: October 27 - November 3, 2019
+  date: October 27 - November 2, 2019
   place: Seoul, Korea
   sub: CV
 


### PR DESCRIPTION
http://iccv2019.thecvf.com/ 
The ICCV 2019 conference end-date have been changed  03. Nov. 2019 to 02. Nov 2019!

Thanks