### PR TITLE
Added options to display in local timezone

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -134,7 +134,7 @@
         }
         addUtcTimeZones();
         var local_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        document.getElementById("local-timezone").innerHTML = local_timezone;
+        document.getElementById("local-timezone").textContent = local_timezone;
 
         // Get all subs
         var conf_type_data = {{ site.data.types | jsonify }};

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -57,11 +57,6 @@
             <div class="row">
               <div class="meta col-xs-12">
                 Export all deadlines to <a href="https://calendar.google.com/calendar/r?cid={{ site.url }}/ai-deadlines.ics">Google Calendar</a> or <a href="/ai-deadlines.ics">.ics</a>.
-                <div class="checkbox">
-                  <label>
-                    <input type="checkbox" id="localtimezone-checkbox"> Display in local timezone: <span id="local-timezone">LOCAL_TIMEZONE</span>
-                  </label>
-                </div>
               </div>
             </div>
         </div>
@@ -107,8 +102,15 @@
         </div>
         {% endfor %}
         <footer>
-          <a href="/">{{ site.domain }}</a> is maintained by <a href="//twitter.com/{{ site.twitter_username }}">@{{ site.twitter_username }}</a>.<br>
-          If you find it useful, consider <a title="_blank" href="https://www.buymeacoffee.com/abhshkdz">buying him a coffee</a>.
+          <div class="row">
+            <div class="col-xs-12 col-sm-6">
+              <a href="/">{{ site.domain }}</a> is maintained by <a href="//twitter.com/{{ site.twitter_username }}">@{{ site.twitter_username }}</a>.<br>
+              If you find it useful, consider <a title="_blank" href="https://www.buymeacoffee.com/abhshkdz">buying him a coffee</a>.
+            </div>
+            <div class="col-xs-12 col-sm-6">
+              All deadlines in <span class="local-timezone"></span> time<br><br>
+            </div>
+          </div>
         </footer>
         <br><br>
     </div>
@@ -134,7 +136,7 @@
         }
         addUtcTimeZones();
         var local_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        document.getElementById("local-timezone").textContent = local_timezone;
+        $('.local-timezone').text(local_timezone.toString());
 
         // Get all subs
         var conf_type_data = {{ site.data.types | jsonify }};
@@ -155,12 +157,14 @@
           // adjust date according to deadline timezone
           var timezone = {% if conf.timezone %}"{{conf.timezone}}" {% else %} "America/New_York" {% endif %};
           var confDate = moment.tz("{{conf.deadline}}", timezone);
+          // convert deadline to local timezone
+          var localConfDate = moment.tz(confDate, local_timezone);
 
           // render countdown timer
           $('#{{conf.id}} .timer').countdown(confDate.toDate(), function(event) {
             $(this).html(event.strftime('%D days %Hh %Mm %Ss'));
           });
-          $('#{{conf.id}} .deadline-time').html(confDate.toString());
+          $('#{{conf.id}} .deadline-time').html(localConfDate.toString());
 
           // add calendar button
           var myCalendar = createCalendar({
@@ -256,22 +260,6 @@
           console.log(subs);
           store.set('{{ site.domain }}', subs);
           window.history.pushState('', '', '/?sub=' + subs.join());
-        });
-
-        // Event handler on local-timezone checkbox change
-        $('#localtimezone-checkbox').change(function(e) {
-          var checked = $(this).is(':checked');
-          {% for conf in site.data.conferences %}
-          var timezone = {% if conf.timezone %}"{{conf.timezone}}" {% else %} "America/New_York" {% endif %};
-          var confDate = moment.tz("{{conf.deadline}}", timezone);
-          {% if conf.deadline != "TBA" %}
-          if (checked){
-            // update the display to local timezone
-            confDate = moment.tz(confDate, local_timezone);
-          }
-          $('#{{conf.id}} .deadline-time').html(confDate.toString());
-          {% endif %}
-          {% endfor %}
         });
     });
     <!-- Google analytics -->

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -57,6 +57,11 @@
             <div class="row">
               <div class="meta col-xs-12">
                 Export all deadlines to <a href="https://calendar.google.com/calendar/r?cid={{ site.url }}/ai-deadlines.ics">Google Calendar</a> or <a href="/ai-deadlines.ics">.ics</a>.
+                <div class="checkbox">
+                  <label>
+                    <input type="checkbox" id="localtimezone-checkbox"> Display in local timezone: <span id="local-timezone">LOCAL_TIMEZONE</span>
+                  </label>
+                </div>
               </div>
             </div>
         </div>
@@ -128,6 +133,8 @@
           }
         }
         addUtcTimeZones();
+        var local_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        document.getElementById("local-timezone").innerHTML = local_timezone;
 
         // Get all subs
         var conf_type_data = {{ site.data.types | jsonify }};
@@ -249,6 +256,22 @@
           console.log(subs);
           store.set('{{ site.domain }}', subs);
           window.history.pushState('', '', '/?sub=' + subs.join());
+        });
+
+        // Event handler on local-timezone checkbox change
+        $('#localtimezone-checkbox').change(function(e) {
+          var checked = $(this).is(':checked');
+          {% for conf in site.data.conferences %}
+          var timezone = {% if conf.timezone %}"{{conf.timezone}}" {% else %} "America/New_York" {% endif %};
+          var confDate = moment.tz("{{conf.deadline}}", timezone);
+          {% if conf.deadline != "TBA" %}
+          if (checked){
+            // update the display to local timezone
+            confDate = moment.tz(confDate, local_timezone);
+          }
+          $('#{{conf.id}} .deadline-time').html(confDate.toString());
+          {% endif %}
+          {% endfor %}
         });
     });
     <!-- Google analytics -->

--- a/_pages/conference.html
+++ b/_pages/conference.html
@@ -35,7 +35,8 @@ permalink:  /conference/
                 </div>
                 <div class="meta deadline col-xs-12">
                   <span id="conf-date"></span>. <span id="conf-place"></span>.<br>
-                  Deadline: <span class="deadline-time"></span><br>
+                  Deadline (conf. timezone): <span class="deadline-time"></span><br>
+                  Deadline (local timezone): <span class="deadline-local-time"></span><br>
                   Website: <a id="conf-website" target="_blank" nohref></a><br>
                 </div>
             </div>
@@ -74,6 +75,7 @@ permalink:  /conference/
           }
         }
         addUtcTimeZones();
+        var local_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
         {% for conf in site.data.conferences %}
             if (conf == "{{ conf.id }}") {
@@ -88,16 +90,20 @@ permalink:  /conference/
               {% if conf.deadline == "TBA" %}
                 $('#conf-timer').html("TBA");
                 $('.deadline-time').html("TBA");
+                $('.deadline-local-time').html("TBA");
               {% else %}
                 // adjust date according to deadline timezone
                 var timezone = {% if conf.timezone %}"{{conf.timezone}}" {% else %} "America/New_York" {% endif %};
                 var confDate = moment.tz("{{conf.deadline}}", timezone);
+                // convert deadline to local timezone
+                var localConfDate = moment.tz(confDate, local_timezone);
 
                 // render countdown timer
                 $('#conf-timer').countdown(confDate.toDate(), function(event) {
                   $(this).html(event.strftime('%D days %Hh %Mm %Ss'));
                 });
                 $('.deadline-time').html(confDate.toString());
+                $('.deadline-local-time').html(localConfDate.toString());
               {% endif %}
             }
         {% endfor %}


### PR DESCRIPTION
This is related to issue #139.

An option of checkbox is added under the meta row. When it is checked, the deadlines will update to the detected local timezone.