### PR TITLE
update SIGGRAPH2019 to SIGGRAPH2020

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -177,13 +177,13 @@
   sub: NLP
 
 - title: SIGGRAPH
-  year: 2019
-  id: siggraph2019
-  link: https://s2019.siggraph.org/
-  deadline: '2019-01-14 22:00:00'
+  year: 2020
+  id: siggraph2020
+  link: https://s2020.siggraph.org/
+  deadline: '2020-01-22 22:00:00'
   timezone: America/Los_Angeles
-  date: July 28 - August 1, 2019
-  place: Los Angeles, California, USA
+  date: July 19 - July 23, 2020
+  place: Washington, D.C., USA
   sub: ML
 
 - title: GECCO


### PR DESCRIPTION
The submission info on SIGGRAPH2020's homepage is updated so I made some update here.

The exact deadline in terms of hour is not clear so I adapted last year's 22:00 which may require further refinement.