### PR TITLE
Adding WSDM and WWW

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -95,6 +95,26 @@
   place: San Diego, California, USA
   sub: DM
 
+- title: WSDM
+  year: 2020
+  id: wsdm20
+  link: http://www.wsdm-conference.org/2020/
+  deadline: '2019-08-16 23:59:59'
+  timezone: UTC-11
+  date: February 3-7, 2020
+  place: Houston, Texas, USA
+  sub: DM
+  
+- title: WWW
+  year: 2020
+  id: www20
+  link: https://www2020.thewebconf.org/
+  deadline: '2019-10-14 23:59:59'
+  timezone: UTC-11
+  date: April 20-24, 2020
+  place: Taipei, Taiwan
+  sub: DM  
+
 - title: IROS
   year: 2020
   id: iros20


### PR DESCRIPTION
WWW is renamed to The Web Conference, but I left the old abbreviation because all the conferences have short abbreviations.

KDD, WWW, WSDM and ICDM are the top tier conference of Data mining
Scholar metrics
Data mining: 
1) https://scholar.google.co.in/citations?view_op=top_venues&hl=en&vq=eng_datamininganalysis 
2) https://scholar.google.co.in/citations?view_op=top_venues&hl=en&vq=eng_databasesinformationsystems