### PR TITLE
Change process.py so it ends in a newline

### DIFF
--- a/utils/process.py
+++ b/utils/process.py
@@ -124,7 +124,7 @@ with open("../_data/conferences.yml", 'r') as stream:
                     Dumper=yaml.SafeDumper,
                     default_flow_style=False,
                     explicit_start=True).splitlines():
-                outfile.write('\n')
                 outfile.write(line.replace('- title:', '\n- title:'))
+                outfile.write('\n')
     except yaml.YAMLError as exc:
         print(exc)


### PR DESCRIPTION
Hey, I noticed that when I submit a change (a PR) through GitHub it always adds a newline at the end of the file, [like in the last PR I sent](https://github.com/abhshkdz/ai-deadlines/pull/216/files#diff-db4cb6c5b8f3c23a1908911314ea4160L447). I'm proposing this change to still make the information be separated by a newline but by making it end with the new line instead of starting with the newline.

The resulting file shouldn't have an empty line at the beginning anymore but now at the end.