### PR TITLE
Adds ACM Conference on Health, Inference, and Learning

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,5 +1,15 @@
 ---
 
+- title: CHIL
+  year: 2020
+  id: chil20
+  link: http://www.chilconference.org/
+  deadline: '2020-01-13 23:59:59'
+  timezone: UTC-12
+  date: April 2-4, 2020
+  place: Toronto, Canada
+  sub: ML
+
 - title: ICMR
   year: 2020
   id: icmr20


### PR DESCRIPTION
Adds submission information for the ACM Conference on Health, Inference, and Learning (CHIL):  http://www.chilconference.org/.