### PR TITLE
Update conferences.yml

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -40,7 +40,7 @@
   date: July 12-18, 2020
   place: Vienna, Austria
   sub: ML
-  note: '<b>NOTE</b>: Mandatory abstract deadline on Jan 31, 2020. More info <a href=''https://icml.cc/Conferences/2020/CallForPapers''>here</a>.'
+  note: '<b>NOTE</b>: Mandatory abstract deadline on Jan 30, 2020. More info <a href=''https://icml.cc/Conferences/2020/CallForPapers''>here</a>.'
 
 - title: KDD
   year: 2020

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -35,8 +35,8 @@
   id: icml20
   link: https://icml.cc/Conferences/2020
   deadline: '2020-02-07 03:59:00'
-  abstract_deadline: '2020-01-31 03:59:00'
-  timezone: America/Los_Angeles
+  abstract_deadline: '2020-01-30 23:59:00'
+  timezone: UTC-12
   date: July 12-18, 2020
   place: Vienna, Austria
   sub: ML


### PR DESCRIPTION
Note ICML's abstract due date is Jan 30th (today), not Jan 31st: https://icml.cc/Conferences/2020/CallForPapers