### PR TITLE
Update NeurIPS 2020

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -492,7 +492,10 @@
   year: 2020
   id: neurips20
   link: https://nips.cc/Conferences/2020
-  deadline: TBA
+  deadline: '2020-05-12 01:00'
+  timezone: PDT
   date: December 6-12, 2020
   place: Vancouver Convention Centre, Canada
   sub: ML
+    note: '<b>NOTE</b>: Mandatory abstract deadline on May 05, 2020.'
+

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -492,7 +492,7 @@
   year: 2020
   id: neurips20
   link: https://nips.cc/Conferences/2020
-  deadline: '2020-05-12 01:00'
+  deadline: '2020-05-12 13:00:00'
   timezone: PDT
   date: December 6-12, 2020
   place: Vancouver Convention Centre, Canada


### PR DESCRIPTION
NeurIPS 2020 deadlines are now available: https://nips.cc/Conferences/2020/Dates