### PR TITLE
updated icpr2020 deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -20,16 +20,6 @@
   place: Las Vegas, USA
   sub: RO
 
-- title: ICPR
-  year: 2020
-  id: icpr20
-  link: https://www.micc.unifi.it/icpr2020
-  deadline: '2020-03-02 23:59:59'
-  timezone: UTC+1
-  date: Sep 13-18, 2020
-  place: Milan, Italy
-  sub: CV
-
 - title: ECCV
   year: 2020
   id: eccv20
@@ -50,6 +40,16 @@
   place: Lima, Peru
   sub: CV
   note: '<b>NOTE</b>: Intent to submit deadline on Mar 03, 2020. More info <a href=''https://www.miccai2020.org/''>here</a>.'
+
+- title: ICPR
+  year: 2020
+  id: icpr20
+  link: https://www.micc.unifi.it/icpr2020
+  deadline: '2020-03-18 23:59:59'
+  timezone: UTC+1
+  date: Sep 13-18, 2020
+  place: Milan, Italy
+  sub: CV
 
 - title: ECML-PKDD
   year: 2020


### PR DESCRIPTION
ICPR 2020 deadline changed to 18 March. Updated conferences.yml accordingly.