### PR TITLE
Update CoRL deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -87,7 +87,7 @@
   year: 2020
   id: corl20
   link: http://www.robot-learning.org
-  deadline: '2020-07-07 23:59:59'
+  deadline: '2020-07-28 23:59:00'
   timezone: UTC-7
   date: November 14-16, 2020
   place: Cambridge, USA


### PR DESCRIPTION
Due to the pandemic, the deadline for CoRL 2020 was postponed to July 28, 2020; 23:59:00 PST (UTC-7).
https://www.robot-learning.org/author-information/call-for-papers