### PR TITLE
EMNLP extended 48 Hours

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -5,7 +5,7 @@
   year: 2020
   id: emnlp20
   link: https://2020.emnlp.org/
-  deadline: '2020-06-01 23:59:00'
+  deadline: '2020-06-03 23:59:00'
   timezone: UTC-12
   date: November 16-20, 2020
   place: Online


### PR DESCRIPTION
https://2020.emnlp.org/

June 1, 2020	The submission deadline has been pushed back 48 hours (now June 3rd) to allow people affected by recent civil unrest and Covid19-related lockdowns some additional time to finalise their papers.