### PR TITLE
aaai fixed year and date

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -171,9 +171,9 @@
   year: 2021
   id: aaai21
   link: https://aaai.org/Conferences/AAAI-21/
-  deadline: '2019-09-09 23:59:59'
+  deadline: '2020-09-09 23:59:59'
   timezone: UTC-12
-  date: February 7-12, 2020
+  date: February 2-9, 2021
   place: Vancouver, Canada
   sub: ML
   note: '<b>NOTE</b>: Mandatory abstract deadline on September 01, 2020'


### PR DESCRIPTION
Sorry, I forgot to change from 2019 to 2020 as well as the conference date