### PR TITLE
Add two features

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -109,7 +109,9 @@
             </div>
             <div class="row">
               <div class="col-xs-12">
-                <span title="Click to only show {{conf.sub}} conferences" data-sub="{{conf.sub}}" class="conf-sub"></span>
+                {% for sub in conf.sub %}
+                <span title="Click to only show {{sub}} conferences" data-sub="{{sub}}" class="conf-sub" id="{{sub}}"></span>
+                {% endfor %}
               </div>
             </div>
             <hr>
@@ -171,7 +173,9 @@
         }
 
         {% for conf in site.data.conferences %}
-        $('#{{conf.id}} .conf-sub').html(sub2name["{{conf.sub}}"].toLocaleLowerCase());
+        {% for sub in conf.sub %}
+        $('#{{conf.id}} #{{sub}}').html(sub2name["{{sub}}"].toLocaleLowerCase());
+        {% endfor %}
         {% if conf.deadline == "TBA" %}
           $('#{{conf.id}} .timer').html("TBA");
           $('#{{conf.id}} .deadline-time').html("TBA");
@@ -243,6 +247,18 @@
         } else {
            subs = subs.toUpperCase().split(',');
         }
+        if (subs != undefined) {
+          // Hide unchecked subs
+          for (var i = 0; i < all_subs.length; i++) {
+            if (subs.indexOf(all_subs[i]) < 0) {
+              $('.' + all_subs[i] + '-conf').hide();
+            }
+          }
+          // In case a conf with multiple types is wrongly hid, show all confs with at least one checked type.
+          for (var i = 0; i < subs.length; i++) {
+            $('.' + subs[i] + '-conf').show();
+          }
+        }
         // Get subjects from browser cache
         if (subs === undefined) {
           subs = all_subs;
@@ -252,12 +268,6 @@
         } else {
           for (var i = 0; i < subs.length; i++) {
             $('#' + subs[i] + '-checkbox').prop('checked', true);
-          }
-        }
-        // Hide unchecked subs
-        for (var i = 0; i < all_subs.length; i++) {
-          if (subs.indexOf(all_subs[i]) < 0) {
-            $('.' + all_subs[i] + '-conf').hide();
           }
         }
         store.set('{{ site.domain }}', subs);
@@ -278,6 +288,10 @@
             var idx = subs.indexOf(csub);
             if (idx >= 0)
               subs.splice(idx, 1);
+            // In case a conf with multiple types (including this type) is wrongly hid, show all confs with at least one checked type.
+            for (var i = 0; i < subs.length; i++) {
+              $('.' + subs[i] + '-conf').show();
+            }
           }
           console.log(subs);
           store.set('{{ site.domain }}', subs);
@@ -292,11 +306,9 @@
               $('#' + subs[i] + '-checkbox').prop('checked', false);
               $('.' + subs[i] + '-conf').hide();
             }
-            else {
-              $('#' + subs[i] + '-checkbox').prop('checked', true);
-              $('.' + subs[i] + '-conf').show();
-            }
           }
+          $('#' + csub + '-checkbox').prop('checked', true);
+          $('.' + csub + '-conf').show();
           subs = [csub];
           console.log(subs);
           store.set('{{ site.domain }}', subs);

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -68,9 +68,10 @@
               </div>
             </div>
         </div>
+        <div id="confs">
         <div id="coming_confs">
           {% for conf in site.data.conferences %}
-          <div id="{{conf.id}}" class="{% for sub in conf.sub %} {{sub}}-conf {% endfor %}">
+          <div id="{{conf.id}}" class="ConfItem {% for sub in conf.sub %} {{sub}}-conf {% endfor %}">
             <div class="row conf-row">
                 <div class="col-xs-5 col-sm-6">
                     <a class="conf-title" href="/conference?id={{ conf.id }}">{{conf.title}} {{conf.year}}</a>
@@ -116,6 +117,7 @@
           {% endfor %}
         </div>
         <div id="past_confs">
+        </div>
         </div>
         <footer>
           <div class="row">
@@ -215,12 +217,23 @@
 
           // check if date has passed, add 'past' class to it
           var today = moment();
-          if (today.diff(confDate) > 0) {
+          diff = today.diff(confDate)
+          $('#{{conf.id}}').attr("diff", diff)
+          if (diff > 0) {
             $('#{{conf.id}}').addClass('past');
             $('#{{conf.id}}').appendTo($("#past_confs"))
           }
         {% endif %}
         {% endfor %}
+
+        // Sort coming_confs and past_confs
+        $("#coming_confs .ConfItem").sort(function (a, b) {
+		    return $(b).attr('diff') - $(a).attr('diff');
+		}).appendTo($("#coming_confs"));
+
+        $("#past_confs .ConfItem").sort(function (a, b) {
+		    return $(b).attr('diff') - $(a).attr('diff');
+		}).appendTo($("#past_confs"));
 
         // Get subjects from URL
         var url = new URL(window.location);

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -110,7 +110,7 @@
             <div class="row">
               <div class="col-xs-12">
                 {% for sub in conf.sub %}
-                <span title="Click to only show {{sub}} conferences" data-sub="{{sub}}" class="conf-sub" id="{{sub}}"></span>
+                <span title="Click to only show {{sub}} conferences" data-sub="{{sub}}" class="conf-sub {{sub}}-tag"></span>
                 {% endfor %}
               </div>
             </div>
@@ -174,7 +174,7 @@
 
         {% for conf in site.data.conferences %}
         {% for sub in conf.sub %}
-        $('#{{conf.id}} #{{sub}}').html(sub2name["{{sub}}"].toLocaleLowerCase());
+        $('#{{conf.id}} .{{sub}}-tag').html(sub2name["{{sub}}"].toLocaleLowerCase());
         {% endfor %}
         {% if conf.deadline == "TBA" %}
           $('#{{conf.id}} .timer').html("TBA");

--- a/static/css/deadlines.css
+++ b/static/css/deadlines.css
@@ -135,6 +135,7 @@ footer {
   background: rgba(236, 240, 241, 0.7);
   font-size: 13px;
   padding: 3px 5px;
+  margin-right: 8px;
   cursor: pointer;
   font-weight: 300;
 }


### PR DESCRIPTION
Add two features:
1. Use JQuery to sort conferences. The order of conferences in `conferences.yml` does not affect how they are shown on the web page now. `utils/process.py` is not needed anymore.
2. A conference can have multiple types now. Multiple types can be set in `conferences.yml`:
```
sub: 
    - DM
    - IR
```
Original one sub per conference is still supported:
```
sub: DM
```

Check the [Demo](http://cddl.lihui.info/). The `The Web Conference 2021`  has two types.