### PR TITLE
Remove CVPR timezone uncertainty note

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -107,7 +107,6 @@
   date: June 19-25, 2021
   place: Nashville, USA
   sub: CV
-  note: '<b>NOTE</b>: Deadline timezone yet to be confirmed'
 
 - title: NAACL
   hindex: 90


### PR DESCRIPTION
CVPR timezone is specified as Pacific on http://cvpr2021.thecvf.com/node/36, so the note is no longer required.