### PR TITLE
Updates the ACM CHIL 2020 deadline.

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,17 @@
 ---
+- title: CHIL
+  hindex: -1
+  year: 2021
+  id: chil21
+  link: https://www.chilconference.org/
+  deadline: '2021-01-11 23:59:59'
+  abstract_deadline: '2021-01-07 23:59:00'
+  timezone: UTC-12
+  date: April 8-10, 2020
+  place: Virtual
+  sub: ML
+  note: '<b>NOTE</b>: Mandatory abstract deadline on Jan 7, 2021. More info at <a href=''https://www.chilconference.org''>chilconference.org</a>.'
+
 - title: ICML
   hindex: 135
   year: 2021

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -8,7 +8,7 @@
   abstract_deadline: '2021-01-07 23:59:59'
   timezone: UTC-12
   date: April 8-10, 2021
-  place: Virtual
+  place: Online
   sub: ML
   note: '<b>NOTE</b>: Mandatory abstract deadline on Jan 7, 2021. More info at <a href=''https://www.chilconference.org''>chilconference.org</a>.'
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -4,13 +4,13 @@
   year: 2021
   id: chil21
   link: https://www.chilconference.org/
-  deadline: '2021-01-11 23:59:59'
-  abstract_deadline: '2021-01-07 23:59:59'
+  deadline: '2021-01-14 23:59:59'
+  abstract_deadline: '2021-01-10 23:59:59'
   timezone: UTC-12
   date: April 8-10, 2021
   place: Online
   sub: ML
-  note: '<b>NOTE</b>: Mandatory abstract deadline on Jan 7, 2021. More info at <a href=''https://www.chilconference.org''>chilconference.org</a>.'
+  note: '<b>NOTE</b>: Recommended abstract deadline on Jan 10, 2021. More info at <a href=''https://www.chilconference.org''>chilconference.org</a>.'
 
 - title: ICML
   hindex: 135

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -7,7 +7,7 @@
   deadline: '2021-01-11 23:59:59'
   abstract_deadline: '2021-01-07 23:59:00'
   timezone: UTC-12
-  date: April 8-10, 2020
+  date: April 8-10, 2021
   place: Virtual
   sub: ML
   note: '<b>NOTE</b>: Mandatory abstract deadline on Jan 7, 2021. More info at <a href=''https://www.chilconference.org''>chilconference.org</a>.'

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -5,7 +5,7 @@
   id: chil21
   link: https://www.chilconference.org/
   deadline: '2021-01-11 23:59:59'
-  abstract_deadline: '2021-01-07 23:59:00'
+  abstract_deadline: '2021-01-07 23:59:59'
   timezone: UTC-12
   date: April 8-10, 2021
   place: Virtual
@@ -280,17 +280,6 @@
   date: June 8-11, 2020
   place: Dublin, Ireland
   sub: CV
-
-- title: CHIL
-  hindex: -1
-  year: 2020
-  id: chil20
-  link: http://www.chilconference.org/
-  deadline: '2020-01-13 23:59:59'
-  timezone: UTC-12
-  date: April 2-4, 2020
-  place: Toronto, Canada
-  sub: ML
 
 - title: SIGGRAPH
   hindex: 20


### PR DESCRIPTION
The abstract and paper submission deadlines have been extended by 3 days. In addition, the abstract deadline has become a recommendation rather than a requirement.