### PR TITLE
Updating the MIDL entry to 2021

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -216,6 +216,8 @@
   date: July 7-9, 2020
   place: Luebeck, Germany
   sub: CV
+  abstract_deadline: '2021-02-10 23:59:59'
+  note: '<b>NOTE</b>: Abstract deadline on Feb 10, 2021. More info <a href=''https://2021.midl.io/dates.html''>here</a>.'
 
 - title: COLT
   hindex: 48

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -213,7 +213,7 @@
   link: https://2021.midl.io/
   deadline: '2021-02-17 23:59:59'
   timezone: UTC-12
-  date: July 7-9, 2020
+  date: July 7-9, 2021
   place: Luebeck, Germany
   sub: CV
   abstract_deadline: '2021-02-10 23:59:59'

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -208,13 +208,13 @@
 
 - title: MIDL
   hindex: -1
-  year: 2020
-  id: midl2020
-  link: https://2020.midl.io/
-  deadline: '2020-01-30 23:59:59'
+  year: 2021
+  id: midl2021
+  link: https://2021.midl.io/
+  deadline: '2021-02-17 23:59:59'
   timezone: UTC-12
-  date: July 6-8, 2020
-  place: Montreal, Canada
+  date: July 7-9, 2020
+  place: Luebeck, Germany
   sub: CV
 
 - title: COLT


### PR DESCRIPTION
This updates MIDL to the 2021 deadline.

What should hindex be set to?

See https://2021.midl.io/dates.html for dates.