### PR TITLE
Add NeurIPS deadline extension

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -30,13 +30,13 @@
   year: 2021
   id: neurips21
   link: https://neurips.cc/Conferences/2021/
-  deadline: '2021-05-26 13:00:00'
-  abstract_deadline: '2021-05-19 13:00:00'
+  deadline: '2021-05-28 13:00:00'
+  abstract_deadline: '2021-05-21 13:00:00'
   timezone: America/Los_Angeles
   date: December 5-14, 2021
   place: Online
   sub: ML
-  note: '<b>NOTE</b>: Mandatory abstract deadline on May 19, 2021'
+  note: '<b>NOTE</b>: Mandatory abstract deadline on May 21, 2021'
 
 - title: ICMI
   hindex: -1


### PR DESCRIPTION
The deadline was recently extended by 48 hours ([link](https://neuripsconf.medium.com/neurips-2021-deadline-extension-c348d8e55c0c)).