### PR TITLE
Add LREC 2022

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -139,13 +139,13 @@
   sub: RO
 
 - title: LREC
-  hindex: 45
-  year: 2020
-  id: lrec20
-  link: https://lrec2020.lrec-conf.org/en/
-  deadline: '2019-12-02 23:59:59'
+  hindex: 38
+  year: 2022
+  id: lrec22
+  link: http://elra.info/en/lrec/lrec-2022/
+  deadline: '2022-01-10 23:59:59'
   timezone: Europe/Paris
-  date: May 11-16, 2020
+  date: June 20-25, 2022
   place: Marseille, France
   sub: NLP
 


### PR DESCRIPTION
Sources:

http://elra.info/en/lrec/lrec-2022/
https://twitter.com/lrec2020/status/1400764312373846016 (I'm guessing the timezone is the same as the last edition, which was supposed to be in the exact same city)
https://scholar.google.com/citations?view_op=top_venues&hl=en&vq=eng_computationallinguistics