### PR TITLE
Add WSDM 2022

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -285,6 +285,17 @@
   place: Fukuoka, Japan
   sub: CV
 
+- title: WSDM
+  hindex: 54
+  year: 2022
+  id: wsdm22
+  link: https://www.wsdm-conference.org/2022/
+  deadline: '2021-08-09 23:59:59'
+  timezone: UTC-12
+  date: February 21-25, 2022
+  place: Phoenix, Arizona, USA
+  sub: DM
+
 - title: WMT
   hindex: 27
   year: 2020


### PR DESCRIPTION
ACM International Conference on Web Search and Data Mining (WSDM, pronounced “wisdom”) is one of the premier conferences on web-inspired research involving search and data mining. The 15th ACM International WSDM Conference will take place in Phoenix, Arizona, 2/21 – 2/25, 2022.

H-index reference: [link](https://www.guide2research.com/conference/wsdm-2021-acm-international-conference-on-web-search-and-data-mining)
WSDM 2022 webset: [link](https://www.wsdm-conference.org/2022/)