### PR TITLE
Fix BMVC

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -107,14 +107,14 @@
   hindex: 57
   year: 2021
   id: bmvc21
-  link: https://britishmachinevisionassociation.github.io/bmvc
+  link: https://www.bmvc2021.com
   deadline: '2021-06-25 23:59:59'
   abstract_deadline: '2021-06-18 23:59:59'
-  timezone: UTC-8
+  timezone: UTC
   date: November 22-25, 2021
   place: Online
   sub: CV
-  note: '<b>NOTE</b>: Mandatory abstract deadline on June 18, 2021. More info <a href=''https://britishmachinevisionassociation.github.io/bmvc''>here</a>.'
+  note: '<b>NOTE</b>: Mandatory abstract deadline on June 18, 2021. More info <a href=''https://www.bmvc2021.com/dates/''>here</a>.'
 
 - title: ALT
   hindex: 15


### PR DESCRIPTION
The BMVC deadline is in UTC-0, not UTC-8.  Also updated to use the link to use the main website.