### PR TITLE
Update NAACL 2022

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,5 +1,16 @@
 ---
 
+- title: NAACL
+  hindex: 105
+  year: 2022
+  id: naacl22
+  link: TBA
+  deadline: '2022-01-15 23:59:00'
+  timezone: UTC-12
+  date: July 10-15, 2022
+  place: Seattle, Washington, USA
+  sub: NLP
+
 - title: ACL
   hindex: 157
   year: 2022
@@ -320,17 +331,6 @@
   date: June 21-24, 2022
   place: New Orleans, Louisiana, USA
   sub: CV
-
-- title: NAACL
-  hindex: 90
-  year: 2021
-  id: naacl21
-  link: https://2021.naacl.org/
-  deadline: '2020-11-23 23:59:00'
-  timezone: UTC-12
-  date: June 6-11, 2021
-  place: Mexico City, Mexico
-  sub: NLP
 
 - title: ICME
   hindex: 30


### PR DESCRIPTION
Hello! 
Although the NAACL website is not open yet, the deadline is out 🥲
https://www.aclweb.org/portal/content/acl-2022-and-naacl-2022-conferences-are-moving-acl-rolling-review

```
NAACL 2022 important dates (for authors)
- Submission deadline to ARR: January 15, 2022 (authors who want their papers to be considered for NAACL 2022 need to submit them to ARR latest by January 15, 2022)
- Commitment deadline for NAACL 2022: March 2, 2022 (deadline for authors to submit their reviewed papers, reviews, and meta-reviews to NAACL 2022)
- Notification of acceptance/rejection: April 7, 2022
- Authors of accepted papers decide to withdraw from NAACL 2022: April 11, 2022
```