### PR TITLE
Add checkbox to sort past events in reverse chronological order

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -146,6 +146,9 @@
         </div>
         <div id="past_confs">
           <h1 id="past-events-title">Past Events</h1>
+          <div id="sort-order-checkbox">
+                <label for="sort-order"><input type="checkbox" id="sort-order" name="sort-order" checked>Most recent first</label>
+            </div>
         </div>
       </div>
       <footer>
@@ -264,9 +267,17 @@
           return $(b).attr('diff') - $(a).attr('diff');
         }).appendTo($("#coming_confs"));
 
-        $("#past_confs .ConfItem").sort(function (a, b) {
-          return $(b).attr('diff') - $(a).attr('diff');
-        }).appendTo($("#past_confs"));
+        $("#sort-order-checkbox input").on("click", function() {
+          if ($("#sort-order-checkbox input").is(":checked")) {
+            $("#past_confs .ConfItem").sort(function (a, b) {
+              return $(a).attr('diff') - $(b).attr('diff');
+            }).appendTo($("#past_confs"));
+          } else {
+            $("#past_confs .ConfItem").sort(function (a, b) {
+              return $(b).attr('diff') - $(a).attr('diff');
+            }).appendTo($("#past_confs"));
+          }
+        });
 
         // Get subjects from URL
         var url = new URL(window.location);

--- a/static/css/deadlines.css
+++ b/static/css/deadlines.css
@@ -154,6 +154,22 @@ footer {
   border-color: #0097e6;
 }
 
+#sort-order-checkbox {
+    text-align: right;
+    font-size: 14px;
+    padding-top: 5px;
+}
+
+#sort-order-checkbox input[type="checkbox"]:checked:after {
+    background-color: #0097e6;
+    border-color: #0097e6;
+  }
+  
+#sort-order-checkbox input[type="checkbox"]:after,
+#sort-order-checkbox input[type="checkbox"]:focus:after {
+    border-color: #0097e6;
+}
+
 .pwc-link {
   color: #1198b2;
   text-decoration: none;
@@ -180,7 +196,6 @@ footer {
 }
 
 #past-events-title {
-  margin-bottom: 30px;
   padding-bottom: 15px;
   border-bottom: 2px solid #bb2d3b;
 }


### PR DESCRIPTION
It would be more relevant to display past events in reverse chronological order (e.g. a deadline just passed and I don't want to scroll all the way to the end to find it). Added checkbox so that people can choose the order in which they want past events displayed.