### PR TITLE
update SIGIR deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -410,12 +410,12 @@
   year: 2022
   id: sigir22
   link: https://sigir.org/sigir2022/
-  deadline: '2022-01-31 23:59:00'
+  deadline: '2022-01-28 23:59:00'
   timezone: UTC-12
   date: July 11-15, 2022
   place: Madrid, Spain
-  abstract_deadline: '2022-01-24 23:59:00'
-  note: '<b>NOTE</b>: Mandatory abstract deadline on January 24, 2022. More info <a href=''https://sigir.org/sigir2022/call-for-papers/''>here</a>.'
+  abstract_deadline: '2022-01-21 23:59:00'
+  note: '<b>NOTE</b>: Mandatory abstract deadline on January 21, 2022. More info <a href=''https://sigir.org/sigir2022/call-for-papers/''>here</a>.'
   sub: DM
 
 - title: MIDL


### PR DESCRIPTION
The deadline for sigir 2022 has been advanced, please refer to https://sigir.org/sigir2022/call-for-papers/