### PR TITLE
Merge IJCAI-22 and IJCAI-ECAI-22

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -82,7 +82,8 @@
   place: Marseille, France
   sub: NLP
 
-- title: IJCAI
+- title: IJCAI-ECAI
+  long: International Joint Conference on Artificial Intelligence and European Conference on Artificial Intelligence
   hindex: 105
   year: 2022
   id: ijcai22
@@ -90,22 +91,9 @@
   deadline: '2022-01-14 23:59:59'
   abstract_deadline: '2022-01-07 23:59:59'
   timezone: UTC-12
-  date: TBD
-  place: Vienna, Austria
-  sub: ML
-
-- title: IJCAI-ECAI
-  long: International Joint Conference on Artificial Intelligence and European Conference on Artificial Intelligence
-  hindex: 105
-  year: 2022
-  id: ecai22
-  link: https://ijcai-22.org/
-  deadline: '2022-01-14 23:59:59'
-  timezone: UTC-12
   date: July 23-29, 2022
   place: Vienna, Austria
   sub: ML
-  host: IJCAI
 
 - title: NAACL
   hindex: 105


### PR DESCRIPTION
There are two different conferences `IJCAI 2022` and `IJCAI-ECAI 2022` on the website.

Actually, they are the same conference. So, it would be better to merge them. Otherwise, it would be very confusuing.