### PR TITLE
extend the ICIP deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -14,7 +14,7 @@
   year: 2022
   id: icip22
   link: https://2022.ieeeicip.org
-  deadline: '2022-02-16 23:59:59'
+  deadline: '2022-02-25 23:59:59'
   timezone: UTC
   date: October, 16-19, 2022
   place: Bordeaux, France


### PR DESCRIPTION
The ICIP deadline has been extended. See https://2022.ieeeicip.org/important-dates/.