### PR TITLE
Add NeurIPS 2022

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -669,19 +669,17 @@
   sub: DM
 
 - title: NeurIPS
-  hindex: 198
-  year: 2021
-  id: neurips21
-  link: https://neurips.cc/Conferences/2021/
-  deadline: '2021-05-28 13:00:00'
-  abstract_deadline: '2021-05-21 13:00:00'
+  hindex: 245
+  year: 2022
+  id: neurips22
+  link: https://neurips.cc/Conferences/2022/
+  deadline: '2022-05-19 13:00:00'
+  abstract_deadline: '2022-05-16 13:00:00'
   timezone: America/Los_Angeles
-  date: December 5-14, 2021
-  place: Online
+  date: Nov 28th - Dec 9th, 2022
+  place: New Orleans, Louisiana, USA; and virtual
   sub: ML
-  note: '<b>NOTE</b>: Mandatory abstract deadline on May 21, 2021'
-  pwclink: https://paperswithcode.com/conference/neurips-2021-12
-  paperslink: https://proceedings.neurips.cc/paper/2021
+  note: '<b>NOTE</b>: Mandatory abstract deadline on May 16, 2022'
 
 - title: WACV
   hindex: 54


### PR DESCRIPTION
* [Source for the h-index](https://scholar.google.com/citations?view_op=top_venues&vq=eng_artificialintelligence)
* [Source for the venue](https://blog.neurips.cc/2021/07/02/neurips-2021-deadline-extension-2/#:~:text=Finally%2C%20we%20are%20pleased%20to,the%20New%20Orleans%20Conference%20Center.)

Fix #420 