### PR TITLE
Update note about hybrid ARR and START for EMNLP 2022

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -13,6 +13,7 @@
   end: 2022-12-11
   hindex: 132
   sub: NLP
+  note: Hybrid format with ARR and START. More info <a href='https://2022.emnlp.org/calls/papers/Overview'>here</a>.
 
 - title: MM
   year: 2022


### PR DESCRIPTION
Hello there!
This year's EMNLP is going hybrid with ACL Rolling Review (ARR) and START, which are two separate submission platforms.
Since this is the first time they are doing this, it's important to note others with this new change in submitting papers.