### PR TITLE
The Learning on Graphs Conference (LoG)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1219,3 +1219,20 @@
   hindex: 12
   sub: CG
   note: part of evostar 2023
+
+- title: LOG
+  year: 2022
+  id: evomusart23
+  full_name: Learning on Graphs Conference
+  link: https://logconference.org/
+  deadline: 2022-16-09 23:59
+  abstract_deadline: 2022-09-09 23:59
+  timezone: UTC-12
+  place: Online
+  date: December, 09-12, 2022
+  start: 2022-12-09
+  end: 2022-12-12
+  paperslink:
+  hindex:
+  sub: ML
+  note: This is the inaugural event of a conference dedicated to Graph Machine Learning

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1222,17 +1222,16 @@
 
 - title: LOG
   year: 2022
-  id: evomusart23
+  id: log22
   full_name: Learning on Graphs Conference
   link: https://logconference.org/
-  deadline: 2022-16-09 23:59
+  deadline: 2022-09-16 23:59
   abstract_deadline: 2022-09-09 23:59
   timezone: UTC-12
   place: Online
   date: December, 09-12, 2022
   start: 2022-12-09
   end: 2022-12-12
-  paperslink:
-  hindex:
   sub: ML
   note: This is the inaugural event of a conference dedicated to Graph Machine Learning
+  


### PR DESCRIPTION
Hi there 👋, 

AI-deadlines is a wonderful initiative.

The Learning on Graphs Conference (LoG) is a new conference dedicated to Graph Machine Learning. It grew out of NeurIPS and ICML and is shaping up to be one of the biggest in the coming years.

The inaugural event is taking place on December 9th, and I think people should be aware of the deadlines for abstract submission (September 9th): https://logconference.org/

Best wishes,
Cheers, 