### PR TITLE
Fix "TypeError: undefined is not an object (evaluating 'sub2name["HCI"].toLocaleLowerCase')"

### DIFF
--- a/_data/types.yml
+++ b/_data/types.yml
@@ -26,3 +26,6 @@
 - name: Knowledge Representation
   sub: KR
   color: "#32a855"
+- name: Human-Computer Interaction
+  sub: HCI
+  color: "#a83232"


### PR DESCRIPTION
The recently merged commit includes a new category "HCI" which has not been added to `types.yml`.
This results in the website not loading correctly due to this error:
```
TypeError: undefined is not an object (evaluating 'sub2name["HCI"].toLocaleLowerCase')
```

I added a new category and verified that the page loads correctly.

This should fix #555 .