### PR TITLE
Adding EACL 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,5 +1,17 @@
 ---
 
+- title: EACL
+  year: 2024
+  id: eacl24
+  deadline: '2023-10-15 23:59:59'
+  timezone: UTC-12
+  place: Malta
+  date: March 17-22, 2024
+  start: 2024-03-17
+  end: 2024-03-22
+  note: Submission via ACL Rolling Review, commitment date 2023-12-20
+  sub: NLP
+
 - title: 3DV
   year: 2024
   id: threedv24


### PR DESCRIPTION
As Publicity Chair of EACL 2024, please contact me with any issues. But the conference is happening and the CfP is out.