### PR TITLE
Add ICASSP 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,4 +1,17 @@
 ---
+- title: ICASSP
+  year: 2024
+  id: icassp24
+  link: https://2024.ieeeicassp.org/
+  deadline: '2023-09-06 23:59:59'
+  timezone: UTC-12
+  place: Seoul, Korea
+  date: April 14-19, 2024
+  start: 2024-04-14
+  end: 2024-04-19
+  hindex: 123
+  sub: SP
+
 - title: WACV
   year: 2024
   id: wacv24


### PR DESCRIPTION
Add ICASSP 2024 as the CFP is out: https://2024.ieeeicassp.org/call_for_papers/