### PR TITLE
Fix CSCW subfield to HCI

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -6,11 +6,11 @@
   deadline: '2024-01-16 23:59:59'
   timezone: UTC-12
   place: San José, Costa Rica
-  date: November, 9-13, 2024
+  date: November 9-13, 2024
   start: 2024-11-09
   end: 2024-11-13
   hindex: 31
-  sub: CSCW
+  sub: HCI
   note: This is the January cycle.
 
 - title: IUI
@@ -20,7 +20,7 @@
   deadline: '2023-10-09 23:59:59'
   timezone: UTC-12
   place: Greenville, South Carolina, USA
-  date: March, 18-21, 2024
+  date: March 18-21, 2024
   start: 2024-03-18
   end: 2024-03-21
   hindex: 47


### PR DESCRIPTION
Sorry, there's an error in the rendering for the current ai-deadlines page. I think I should've fixed the subfield to HCI for CSCW.