### PR TITLE
COLING 2024 - Website link change

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -243,7 +243,7 @@
   year: 2024
   id: lreccoling24
   full_name: The 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation
-  link: https://lrec-coling-2024.lrec-conf.org/
+  link: https://lrec-coling-2024.org
   deadline: '2023-10-13 23:59:59'
   timezone: UTC-12
   place: Torino, Italy


### PR DESCRIPTION
LREC-COLING 2024 has changed their website link to https://lrec-coling-2024.org