### PR TITLE
URGENT: COLING/AISTATS Delayed

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -116,7 +116,7 @@
   year: 2024
   id: aistats24
   link: https://www.aistats.org/aistats2024/
-  deadline: '2023-10-13 23:59:59'
+  deadline: '2023-10-16 23:59:59'
   timezone: UTC-12
   place: Valencia, Spain
   date: May 02-04, 2024
@@ -317,7 +317,7 @@
   id: lreccoling24
   full_name: The 2024 Joint International Conference on Computational Linguistics, Language Resources and Evaluation
   link: https://lrec-coling-2024.org
-  deadline: '2023-10-13 23:59:59'
+  deadline: '2023-10-20 23:59:59'
   timezone: UTC-12
   place: Torino, Italy
   date: May 20 - May 25, 2024


### PR DESCRIPTION
http://aistats.org/aistats2024/
The AISTATS deadline has been postponed to October 16 (Anywhere on Earth) in support of AISTATS community members affected by the events in the Middle East. The Appendix deadline will be postponed to October 23.


https://twitter.com/LrecColing/status/1711452954816110699
Important message: The LREC-COLING deadline was extended by one week to Oct 20. Please RT! 