### PR TITLE
Move ICML'24 deadline to midnight AOE, not midday AOE

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -179,7 +179,7 @@
   year: 2024
   id: icml24
   link: https://icml.cc/Conferences/2024
-  deadline: '2024-02-01 11:59:00'
+  deadline: '2024-02-01 23:59:59'
   timezone: UTC-12
   place: Vienna, Austria
   date: July 21-27, 2024


### PR DESCRIPTION
Currently the ICML'24 deadline on aideadlin.es is listed as midnight UTC/midday AOE:

![image](https://github.com/paperswithcode/ai-deadlines/assets/1258993/13233d5f-aa44-4312-a1f2-4e17a196acf0)

However, it should actually be midnight AOE [according to icml.cc](https://icml.cc/Conferences/2024/Dates):

![image](https://github.com/paperswithcode/ai-deadlines/assets/1258993/f4c79ca3-6337-47b6-9ebc-a4d344743a34)

The actual [data in this repo](https://github.com/paperswithcode/ai-deadlines/blob/f365ce2ab5e7a92e3a26da82801b75ef0e3f832e/_data/conferences.yml#L178-L189) seems to have listed the deadline as 11:59 in UTC-12 rather than 23:59 in UTC-12. This PR changes it to 23:59:59 in UTC-12.
