### PR TITLE
Update CHIL 2024

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -251,8 +251,8 @@
   id: CHIL24
   full_name: Conference on Health, Inference, and Learning
   link: https://www.chilconference.org/index.html
-  deadline: '2024-02-05 23:59:59'
-  timezone: America/New_York
+  deadline: '2024-02-16 23:59:59'
+  timezone: UTC-14
   place: New York, New York
   date: June, 27-28, 2024
   start: 2024-06-27

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -252,7 +252,7 @@
   full_name: Conference on Health, Inference, and Learning
   link: https://www.chilconference.org/index.html
   deadline: '2024-02-16 23:59:59'
-  timezone: UTC-14
+  timezone: UTC-12
   place: New York, New York
   date: June, 27-28, 2024
   start: 2024-06-27


### PR DESCRIPTION
This updates our extended deadline for CHIL 2024 and sets the timezone to UTC-14 / anywhere in the world.