### PR TITLE
Update conferences.yml to reflect RLC extension

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -163,7 +163,8 @@
   year: 2024
   id: rlc24
   link: https://rl-conference.cc/
-  deadline: '2024-03-01 23:59:59'
+  deadline: '2024-03-08 23:59:59'
+  abstract_deadline: '2024-03-01 23:59:59'
   timezone: UTC-12
   place: Amherst, Massachusetts, USA
   date: August 09-12, 2024


### PR DESCRIPTION
Separated abstract deadline (March 1) and paper deadline (March 8, extended) for RLC.

Reference for extension: https://x.com/RL_Conference/status/1762924191064432839?s=20