### PR TITLE
fix the error of not showing conference deadlines

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,6 +1,6 @@
 - title: KIL
   year: 2024
-  Id: kil24
+  id: kil24
   full_name: KDD Workshop on Knowledge-infused Learning
   link: https://kil-workshop.github.io/
   deadline: '2024-05-25 23:59:59'


### PR DESCRIPTION
It didn't show the deadline for all conferences. There was a minor typo in the config file, conferences.yml, and I fixed this (Id->id.)