### PR TITLE
Correct errors on neurips24

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -72,14 +72,17 @@
   year: 2024
   id: neurips24
   full_name: Conference on Neural Information Processing Systems
+  hindex: 309
   link: https://nips.cc/Conferences/2024
-  deadline: '2024-05-22 23:59:59'
-  abstract_deadline: '2024-05-15 23:59:59'
+  paperslink: https://proceedings.neurips.cc/
+  pwclink: https://paperswithcode.com/conference/neurips-2024-12
+  deadline: '2024-05-22 19:59:59'
+  abstract_deadline: '2024-05-15 19:59:59'
   timezone: UTC
   place: Vancouver, Canada
   date: December 9 - December 15, 2024
   start: 2024-12-09
-  end: 2023-12-15
+  end: 2024-12-15
   sub: ML
   note: Mandatory abstract deadline on May 15, 2024
 


### PR DESCRIPTION
+ Added [hindex](https://scholar.google.es/citations?view_op=list_hcore&venue=eqYFflc_uhEJ.2023), [paperslink](https://proceedings.neurips.cc/), [pwclink](https://paperswithcode.com/conference/neurips-2024-12) (pwclink is currently inactive, it will be active after proceedings are uploaded)

+ Corrected errors on deadline and end tag (see: https://neurips.cc/Conferences/2024/Dates)