### PR TITLE
Add WSDM 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: WSDM
+  full_name: ACM International Conference on Web Search and Data Mining
+  note: Abstract deadline on August 7, 2024
+  year: 2025
+  id: wsdm25
+  link: https://www.wsdm-conference.org/2025/
+  deadline: '2024-08-14 23:59:00'
+  timezone: UTC-12
+  place: Hannover, Germany
+  date: March 10-14, 2025
+  start: 2025-03-10
+  end: 2025-03-14
+  sub: DM
+
 - title: Iberamia
   year: 2024
   id: iberamia24


### PR DESCRIPTION
The 18th ACM International Conference on Web Search and Data Mining | March 10th-14th, 2025  | Hannover, Germany https://www.wsdm-conference.org/2025/call-for-papers/

2023 and earlier were previously on aideadlin.es