### PR TITLE
Add IJCAI25 conference deadline

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: IJCAI
+  year: 2025
+  id: ijcai25
+  link: https://2025.ijcai.org/
+  deadline: '2025-01-23 23:59:59'
+  abstract_deadline: '2025-01-16 23:59:59'
+  timezone: UTC-12
+  place: Montreal, Canada
+  date: August 16-22, 2025
+  start: 2025-08-16
+  end: 2025-08-22
+  hindex: 136
+  sub: ML
+  note: Mandatory abstract deadline on January 16, 2025. More info <a href='https://2025.ijcai.org/'>here</a>.
+
 - title: AISTATS
   year: 2025
   id: aistats25


### PR DESCRIPTION
Add the IJCAI 2025 conference deadline from https://2025.ijcai.org/important-dates/