### PR TITLE
Adjusting AAAI25 starting date

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -227,8 +227,8 @@
   abstract_deadline: '2024-08-07 23:59:59'
   timezone: UTC-12
   place: Philadelphia, USA
-  date: February 25 - March 04, 2025
-  start: 2025-02-25
+  date: February 27 - March 04, 2025
+  start: 2025-02-27
   end: 2025-03-04
   hindex: 212
   sub: ['DM', 'KR', 'ML', 'RO', 'NLP', 'SP', 'CV', 'CG', 'HCI', 'AP']


### PR DESCRIPTION
The starting date of AAAI 25 is Feb 27, according to the website:
https://aaai.org/conference/aaai/aaai-25/

![image](https://github.com/user-attachments/assets/ed16b5f1-a726-407e-bc7d-81eb23534e98)
