### PR TITLE
Add VehicleSec 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: VehicleSec
+  year: 2025
+  id: vehiclesec25
+  full_name: USENIX Vehicle Security and Privacy
+  link: https://www.usenix.org/conference/vehiclesec25/call-for-papers
+  deadline: '2025-02-27 23:59:59'
+  timezone: UTC-12
+  place: Seattle, WA, USA
+  date: August 11 - August 12, 2025
+  start: 2025-08-11
+  end: 2025-08-12
+  sub: ['RO', 'ML', 'CV', 'AP', 'HCI']
+  note: More info <a href='https://www.usenix.org/conference/vehiclesec25/call-for-papers'>here</a>. 
+  
 - title: AISTATS
   year: 2025
   id: aistats25


### PR DESCRIPTION
I would like to add VehicleSec 2025 conference.

VehicleSec is the third symposium on Vehicle Security and Privacy that will be co-located with USENIX Security. While the conference name emphasizes security and robotics, its scope is broad, as autonomous systems (e.g., autonomous vehicles) require interdisciplinary research encompassing machine learning, computer vision, and human-computer interaction.

Thank you!