### PR TITLE
Add COLT 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: COLT
+  year: 2025
+  id: colt225
+  link: https://aistats.org/aistats2025/index.html
+  deadline: '2025-02-06 10:00:00'
+  abstract_deadline: '2024-02-06 10:00:00'
+  timezone: UTC-12
+  place: Lyon, France
+  date: Jun 30 - July 04, 2025
+  start: 2025-06-30
+  end: 2025-07-04
+  hindex: 100
+  sub: ML
+  note: More info regarding the important dates can be found <a href='https://learningtheory.org/colt2025/index.html#important-dates'>here</a>
+
 - title: AISTATS
   year: 2025
   id: aistats25


### PR DESCRIPTION
Add information and track the timing for the Annual Conference on Learning Theory in Lyon, France, scheduled for late June or early July.

I've been checking some recent PRs, but no one added COLT. So, I am raising a PR here. Hope this helps.