### PR TITLE
Added MIPR 2025 conference details.

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: MIPR
+  year: 2025
+  id: mipr25
+  full_name: IEEE International Conference on Multimedia Information Processing and Retrieval
+  link: http://www.ieee-mipr.org
+  deadline: 2025-03-15 23:59
+  timezone: America/Los_Angeles
+  place: San Jose, CA, USA
+  date: August 6–8, 2025
+  start: 2025-08-06
+  end: 2025-08-08
+  paperslink: https://cmt3.research.microsoft.com/MIPR2025
+  sub: Multimedia
+  note: Includes keynote speeches, workshops, tutorials, and challenge contests.
+
 - title: AISTATS
   year: 2025
   id: aistats25


### PR DESCRIPTION
This PR adds the IEEE MIPR 2025 conference details to the conferences.yml file, including the deadline, location, and related information.