### PR TITLE
Add 2027 deadlines and fix calendar dates

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,17 @@
+- title: SaTML
+  year: 2027
+  id: satml27
+  full_name: IEEE Conference on Secure and Trustworthy Machine Learning
+  link: https://satml.org/
+  deadline: '2026-09-29 23:59:59'
+  timezone: UTC-12
+  place: Reykjavik, Iceland
+  date: Early May, 2027
+  start: ''
+  end: ''
+  sub: ML
+  note: Exact conference dates are TBA. More info <a href='https://satml.org/call-for-papers/'>here</a>.
+
 - title: AISTATS
   year: 2025
   id: aistats25

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1,3 +1,18 @@
+- title: FAccT
+  year: 2027
+  id: facct27
+  full_name: ACM Conference on Fairness, Accountability, and Transparency
+  link: https://facctconference.org/2027/cfp.html
+  deadline: '2026-11-03 23:59:59'
+  abstract_deadline: '2026-10-27 23:59:59'
+  timezone: UTC-12
+  place: TBA
+  date: June 21-24, 2027
+  start: 2027-06-21
+  end: 2027-06-24
+  sub: ML
+  note: Mandatory abstract deadline on October 27, 2026. More info <a href='https://facctconference.org/2027/cfp.html'>here</a>.
+
 - title: SaTML
   year: 2027
   id: satml27

--- a/_includes/calendar.js
+++ b/_includes/calendar.js
@@ -81,6 +81,30 @@
         },
         dataSource: conf_list_all
       }
+function parse_local_date(date_string) {
+  var parts = date_string.split("-");
+  if (parts.length !== 3) {
+    return new Date(date_string);
+  }
+
+  return new Date(
+    parseInt(parts[0], 10),
+    parseInt(parts[1], 10) - 1,
+    parseInt(parts[2], 10)
+  );
+}
+
+function parse_deadline(date_string, timezone) {
+  var fixed_offset = timezone.match(/^(?:UTC|GMT)([+-]\d{1,2})$/);
+  if (fixed_offset) {
+    return moment.utc(date_string)
+      .subtract(parseInt(fixed_offset[1], 10), "hours")
+      .toDate();
+  }
+
+  return moment.tz(date_string, timezone).toDate();
+}
+
 function load_conference_list() {
   // Gather data
   var conf_list_all = [];
@@ -95,8 +119,8 @@ function load_conference_list() {
       date: "{{conf.date}}",
       hindex: "{{conf.hindex}}",
       subject: "{{conf.sub}}",
-      startDate: Date.parse("{{conf.deadline}}"),
-      endDate: Date.parse("{{conf.deadline}}"),
+      startDate: parse_deadline("{{conf.deadline}}", "{{conf.timezone}}"),
+      endDate: parse_deadline("{{conf.deadline}}", "{{conf.timezone}}"),
     });
 
     // add Conferences in chosen color
@@ -117,8 +141,8 @@ function load_conference_list() {
         date: "{{conf.date}}",
         hindex: "{{conf.hindex}}",
         subject: "{{conf.sub}}",
-        startDate: Date.parse("{{conf.start}}"),
-        endDate: Date.parse("{{conf.end}}"),
+        startDate: parse_local_date("{{conf.start}}"),
+        endDate: parse_local_date("{{conf.end}}"),
       });
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
## Summary of This PR

Adds SaTML 2027 and FAccT 2027 from their official calls for papers. Fixes #640 by parsing date-only conference dates in local time and applying configured timezones to deadlines.

Checks: YAML parsing, timezone tests, GitHub Pages build

Sources: [SaTML 2027](https://satml.org/call-for-papers/), [FAccT 2027](https://facctconference.org/2027/cfp.html), [issue #640](https://github.com/paperswithcode/ai-deadlines/issues/640)